### PR TITLE
[FIX]Fixed missing type replacement in _type_to_str

### DIFF
--- a/cligenerator/cligenerator.py
+++ b/cligenerator/cligenerator.py
@@ -152,7 +152,8 @@ class CLIGenerator(object):
 
         def _type_to_str(type_):
             return repr(type_).replace('<class ', '').replace(
-                '>', '').replace("'", '').replace('Type', '')
+                '>', '').replace("'", '').replace('Type', '').replace('<type ',
+                                                                      '')
 
         try:
             return _type_to_str(self.option_types[func.__module__][
@@ -253,7 +254,8 @@ class CLIGenerator(object):
                 additional_opts += ', action=\'store_true\''
 
             if option_type == 'list':
-                additional_opts += ', nargs=\'*\''  # nargs=* is zero or more values
+                additional_opts += ', nargs=\'*\''  
+                # nargs=* is zero or more values
 
             if option_type == 'dict':
                 self.additional_imports.append('json')


### PR DESCRIPTION
Hi,

I just used your script, and found that an issue happened.
During argument generations, I had code like:
```python
parser.add_argument('--username', type=<type str, default='')
```
where I was only wanting to get the str type
```python
parser.add_argument('--username', type=str, default='')
```

If you have any question, I'll be happy to answer them
(Very nice tool you made by the way, looking forward to use it !)